### PR TITLE
Fix javascript error in chrome

### DIFF
--- a/files/gerrit/Resources/JavaScript/Form.js
+++ b/files/gerrit/Resources/JavaScript/Form.js
@@ -11,7 +11,7 @@
       passwordField = document.getElementById("f_pass");
 
       showBody();
-      if (form.length > 0) {
+      if (form && form.length > 0) {
         renderPlaceholder();
         renderErrorMessage();
       }

--- a/files/gerrit/Resources/JavaScript/Form.js
+++ b/files/gerrit/Resources/JavaScript/Form.js
@@ -27,7 +27,7 @@
       setTimeout(function() {
         var body = document.getElementsByTagName("body");
         console.log(body);
-        if (body.length) {
+        if (body && body.length) {
           body[0].style.visibility = "visible";
         }
       }, 500);


### PR DESCRIPTION
when i was on https://review.typo3.org/#/q/status:open i saw a javascript error

Uncaught TypeError: Cannot read property 'length' of null
    at a (Form.js:14)
    at window.onload (Form.js:74)
    at w (gerrit_ui.nocache.js:4)
    at v (gerrit_ui.nocache.js:3)
    at m (gerrit_ui.nocache.js:9)
    at gerrit_ui.nocache.js:10
    at HTMLDocument.d (gerrit_ui.nocache.js:6)

which leads to this line:

if (form.length > 0) {

by doing form && form.length it prevents the error from happening.