### PR TITLE
Authentication type configurable and new test default

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,6 +41,7 @@ suites:
       gerrit:
         config:
           auth:
+            type: DEVELOPMENT_BECOME_ANY_ACCOUNT
             registerEmailPrivateKey: 123123123
             restTokenPrivateKey: 123123123
             cookieSecure: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,6 +12,8 @@ default['gerrit']['config']['httpd']['listenUrl'] = 'proxy-https://*:8080/'
 default['gerrit']['config']['database']['type'] = "MYSQL"
 #<> Database name
 default['gerrit']['config']['database']['database'] = "gerrit"
+#<> Set authentication type
+default['gerrit']['config']['auth']['type'] = 'LDAP'
 #<> Set cookieSecure attribute
 default['gerrit']['config']['auth']['cookieSecure'] = true
 #<> Use HTTP basic auth for Git via HTTP (instead of additional HTTP passwords)

--- a/templates/gerrit/gerrit.config.erb
+++ b/templates/gerrit/gerrit.config.erb
@@ -25,7 +25,9 @@
 	type = LUCENE
 [auth]
 	type = <%= node['gerrit']['config']['auth']['type'] %>
+<% if node['gerrit']['config']['auth']['type'] == 'LDAP' %>
 	gitBasicAuthPolicy = HTTP_LDAP
+<% end %>
 	; allowing anonymous access to gerrit by explicitly setting the loginUrl
 	loginUrl = login/
 	cookieSecure = <%= node['gerrit']['config']['auth']['cookieSecure'] %>

--- a/templates/gerrit/gerrit.config.erb
+++ b/templates/gerrit/gerrit.config.erb
@@ -24,7 +24,7 @@
 [index]
 	type = LUCENE
 [auth]
-	type = LDAP
+	type = <%= node['gerrit']['config']['auth']['type'] %>
 	gitBasicAuthPolicy = HTTP_LDAP
 	; allowing anonymous access to gerrit by explicitly setting the loginUrl
 	loginUrl = login/


### PR DESCRIPTION
Make authentication type configurable and add `DEVELOPMENT_BECOME_ANY_ACCOUNT` as default when testing