### PR TITLE
[TASK] Upgrade Gerrit to 2.15.10

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 #<> Gerrit version
-default['gerrit']['version'] = '2.14.18'
+default['gerrit']['version'] = '2.15.8'
 #<> Gerrit host name
 default['gerrit']['hostname'] = "review.typo3.org"
 #<> Gerrit's URL (used in emails etc)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 #<> Gerrit version
-default['gerrit']['version'] = '2.15.8'
+default['gerrit']['version'] = '2.15.10'
 #<> Gerrit host name
 default['gerrit']['hostname'] = "review.typo3.org"
 #<> Gerrit's URL (used in emails etc)


### PR DESCRIPTION
On production the upgrade fails with
```              Migrating data to schema 147 ...
              Exception in thread "main" com.google.gwtorm.server.OrmException: update failure on schema_version
              	at com.google.gwtorm.schema.sql.SqlDialect.convertError(SqlDialect.java:162)
              	at com.google.gwtorm.schema.sql.DialectMySQL.convertError(DialectMySQL.java:232)
              	at com.google.gwtorm.jdbc.JdbcAccess.convertError(JdbcAccess.java:489)
              	at com.google.gwtorm.jdbc.JdbcAccess.update(JdbcAccess.java:232)
              	at com.google.gerrit.server.schema.SchemaVersion.finish(SchemaVersion.java:173)
              	at com.google.gerrit.server.schema.SchemaVersion.migrateData(SchemaVersion.java:154)
              	at com.google.gerrit.server.schema.SchemaVersion.upgradeFrom(SchemaVersion.java:92)
              	at com.google.gerrit.server.schema.SchemaVersion.check(SchemaVersion.java:83)
              	at com.google.gerrit.server.schema.SchemaUpdater.update(SchemaUpdater.java:118)
              	at com.google.gerrit.pgm.init.BaseInit$SiteRun.upgradeSchema(BaseInit.java:389)
              	at com.google.gerrit.pgm.init.BaseInit.run(BaseInit.java:146)
              	at com.google.gerrit.pgm.util.AbstractProgram.main(AbstractProgram.java:61)
              	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
              	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
              	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
              	at java.lang.reflect.Method.invoke(Method.java:498)
              	at com.google.gerrit.launcher.GerritLauncher.invokeProgram(GerritLauncher.java:223)
              	at com.google.gerrit.launcher.GerritLauncher.mainImpl(GerritLauncher.java:119)
              	at com.google.gerrit.launcher.GerritLauncher.main(GerritLauncher.java:63)
              	at Main.main(Main.java:24)
              Caused by: java.sql.SQLException: No operations allowed after statement closed.
              	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:964)
              	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:897)
              	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:886)
              	at com.mysql.jdbc.SQLError.createSQLException(SQLError.java:860)
              	at com.mysql.jdbc.StatementImpl.checkClosed(StatementImpl.java:442)
              	at com.mysql.jdbc.PreparedStatement.clearBatch(PreparedStatement.java:1003)
              	at com.mysql.jdbc.PreparedStatement.executeBatchInternal(PreparedStatement.java:1266)
              	at com.mysql.jdbc.StatementImpl.executeBatch(StatementImpl.java:970)
              	at com.google.gwtorm.schema.sql.SqlDialect.executeBatch(SqlDialect.java:448)
              	at com.google.gwtorm.jdbc.JdbcAccess.execute(JdbcAccess.java:460)
              	at com.google.gwtorm.jdbc.JdbcAccess.updateAsBatch(JdbcAccess.java:276)
              	at com.google.gwtorm.jdbc.JdbcAccess.update(JdbcAccess.java:227)
              	... 16 more
```
but running another init by
`java -jar /var/gerrit/review/bin/gerrit.war init --no-auto-start -d /var/gerrit/review --install-plugin replication --install-plugin commit-message-length-validator --install-plugin reviewnotes --install-plugin download-commands`
finishes the migration (without need for offline reindexing). Without `--batch` is important as otherwise drafts are converted to public WIP patches. 

As the issue does not exist in a clean Gerrit installation, there is [no progress on Gerrit side to fix this](https://bugs.chromium.org/p/gerrit/issues/detail?id=9734) and the workaround mentioned above is available I propose to upgrade using it.